### PR TITLE
Add subpath support for monorepo apps

### DIFF
--- a/AllGasNoBrakes/app.py
+++ b/AllGasNoBrakes/app.py
@@ -4,7 +4,15 @@ import os
 # Define environment detection
 IS_DEVELOPMENT = os.environ.get('FLASK_ENV') == 'development'
 
+# Base path for deployment under a subdirectory
+BASE_PATH = os.environ.get('BASE_PATH', '/allgasnobrakes')
+
 app = Flask(__name__)
+
+
+@app.context_processor
+def inject_base_path():
+    return {"base_path": BASE_PATH}
 
 @app.after_request
 def add_security_headers(response):
@@ -18,8 +26,8 @@ def page_not_found(e):
     if IS_DEVELOPMENT:
         app.logger.error(f"404 error: {request.path}")
     
-    # Redirect to the index page
-    return redirect(url_for('index'))
+    # Redirect to the index page respecting base path
+    return redirect(BASE_PATH + url_for('index'))
 
 @app.route('/')
 def index():

--- a/AllGasNoBrakes/templates/base.html
+++ b/AllGasNoBrakes/templates/base.html
@@ -7,14 +7,14 @@
 
     <title>{% block title %}AllGasNoBrakes Photography{% endblock %}</title>
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='default.css') }}">
+    <link rel="stylesheet" href="{{ base_path + url_for('static', filename='default.css') }}">
 
     {% block head %}{% endblock %}
 </head>
-<body>
+<body data-base-path="{{ base_path }}">
     {% block body %}{% endblock %}
 
-    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+    <script src="{{ base_path + url_for('static', filename='js/script.js') }}"></script>
 
     {% block scripts %}{% endblock %}
 </body>

--- a/AllGasNoBrakes/templates/index.html
+++ b/AllGasNoBrakes/templates/index.html
@@ -29,8 +29,8 @@
                     {% for j in range(3) %}
                         {% if i + j < photos|length %}
                         <div class="image-wrapper">
-                            <a href="{{ url_for('view_image', filename=photos[i + j]) }}">
-                                <img src="{{ url_for('static', filename='photos/' + photos[i + j]) }}"
+                            <a href="{{ base_path + url_for('view_image', filename=photos[i + j]) }}">
+                                <img src="{{ base_path + url_for('static', filename='photos/' + photos[i + j]) }}"
                                      alt="Automotive Photography {{ i + j + 1 }}"
                                      loading="{% if i == 0 and j == 0 %}eager{% else %}lazy{% endif %}">
                             </a>

--- a/AllGasNoBrakes/templates/view_image.html
+++ b/AllGasNoBrakes/templates/view_image.html
@@ -56,10 +56,10 @@
 
 {% block body %}
 <div class="fullsize-container">
-    <img src="{{ url_for('get_photo', filename=filename) }}" alt="{{ filename }}" class="fullsize-image">
-    
+    <img src="{{ base_path + url_for('get_photo', filename=filename) }}" alt="{{ filename }}" class="fullsize-image">
+
     <div class="image-controls">
-        <a href="{{ url_for('index') }}" class="control-button">
+        <a href="{{ base_path + url_for('index') }}" class="control-button">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M9 20H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h3"></path>
                 <path d="M16 4h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-3"></path>

--- a/CampingCalendar/api/index.py
+++ b/CampingCalendar/api/index.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__, template_folder='../templates', static_folder='../static')
 
+# Base path for deployment under subdirectory
+BASE_PATH = os.environ.get('BASE_PATH', '/camping')
+
+
+@app.context_processor
+def inject_base_path():
+    return {"base_path": BASE_PATH}
+
 # Define users and months
 USERS = ["Jack", "Payton", "Nick", "Alyssa"]
 MONTHS_YEAR = [(2025, m) for m in range(5, 9)]  # May to August 2025

--- a/CampingCalendar/static/js/script.js
+++ b/CampingCalendar/static/js/script.js
@@ -1,4 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
+    const basePath = document.body.dataset.basePath || '';
+    const originalFetch = window.fetch;
+    window.fetch = (url, options, ...rest) => {
+        if (typeof url === 'string' && url.startsWith('/')) {
+            return originalFetch(basePath + url, options, ...rest);
+        }
+        return originalFetch(url, options, ...rest);
+    };
+
     // --- Removed userSelect element reference ---
     // const userSelect = document.getElementById('user-select');
     const userButtonsContainer = document.getElementById('user-buttons'); // Get user button group

--- a/CampingCalendar/templates/index.html
+++ b/CampingCalendar/templates/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Camping Coordinator</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ base_path + url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body data-base-path="{{ base_path }}">
     <h1>Camping Date Coordinator</h1>
     <p>Select your name, choose a preference, and click dates for May-August 2025.</p>
 
@@ -80,6 +80,6 @@
 
     <div id="message-area" class="message-area"></div> <!-- Added base class for consistency -->
 
-    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+    <script src="{{ base_path + url_for('static', filename='js/script.js') }}"></script>
 </body>
 </html>

--- a/MovieRatings/api/index.py
+++ b/MovieRatings/api/index.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__, template_folder='../templates', static_folder='../static')
 
+# Base path for deployment under subdirectory
+BASE_PATH = os.environ.get('BASE_PATH', '/movieratings')
+
+
+@app.context_processor
+def inject_base_path():
+    return {"base_path": BASE_PATH}
+
 
 def _get_basic_auth_credentials():
     """Extract basic auth credentials from the request."""

--- a/MovieRatings/static/js/admin.js
+++ b/MovieRatings/static/js/admin.js
@@ -1,4 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
+    const basePath = document.body.dataset.basePath || '';
+    const originalFetch = window.fetch;
+    window.fetch = (url, options, ...rest) => {
+        if (typeof url === 'string' && url.startsWith('/')) {
+            return originalFetch(basePath + url, options, ...rest);
+        }
+        return originalFetch(url, options, ...rest);
+    };
+
     const usersDiv = document.getElementById('users');
     const moviesDiv = document.getElementById('movies');
     const addUserBtn = document.getElementById('admin-add-user');

--- a/MovieRatings/static/js/script.js
+++ b/MovieRatings/static/js/script.js
@@ -1,4 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
+    const basePath = document.body.dataset.basePath || '';
+    const originalFetch = window.fetch;
+    window.fetch = (url, options, ...rest) => {
+        if (typeof url === 'string' && url.startsWith('/')) {
+            return originalFetch(basePath + url, options, ...rest);
+        }
+        return originalFetch(url, options, ...rest);
+    };
+
     // State management
     let currentUser = 'Jack';
     let currentFilter = 'all';

--- a/MovieRatings/templates/admin.html
+++ b/MovieRatings/templates/admin.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin Panel</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ base_path + url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body data-base-path="{{ base_path }}">
     <div class="container">
         <h1>Admin Panel</h1>
         <p>
-            <a href="/">Main Page</a> |
-            <a href="/tests">Tests</a>
+            <a href="{{ base_path }}/">Main Page</a> |
+            <a href="{{ base_path }}/tests">Tests</a>
         </p>
         <p>
             <button type="button" id="rescale-elo-btn">Recalculate Elo</button>
@@ -22,6 +22,6 @@
         <h2>Movies</h2>
         <div id="movies"></div>
     </div>
-    <script src="{{ url_for('static', filename='js/admin.js') }}"></script>
+    <script src="{{ base_path + url_for('static', filename='js/admin.js') }}"></script>
 </body>
 </html>

--- a/MovieRatings/templates/index.html
+++ b/MovieRatings/templates/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Movie Ratings - Personal Ranking System</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ base_path + url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body data-base-path="{{ base_path }}">
     <div class="container">
         <h1>Movie Rankings</h1>
         
@@ -55,6 +55,6 @@
         <div id="message-area" class="message-area"></div>
     </div>
 
-    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+    <script src="{{ base_path + url_for('static', filename='js/script.js') }}"></script>
 </body>
 </html>

--- a/MovieRatings/templates/tests.html
+++ b/MovieRatings/templates/tests.html
@@ -120,10 +120,10 @@
         }
     </style>
 </head>
-<body>
+<body data-base-path="{{ base_path }}">
     <h1>Movie Ratings Test Suite</h1>
-    <p><a href="/">Back to Main Page</a></p>
-    <p><a href="/admin">Admin Page</a></p>
+    <p><a href="{{ base_path }}/">Back to Main Page</a></p>
+    <p><a href="{{ base_path }}/admin">Admin Page</a></p>
     
     <!-- Database Status -->
     <div class="test-section">
@@ -727,6 +727,15 @@
         }
 
         // Run initial check on page load
+        const basePath = document.body.dataset.basePath || '';
+        const originalFetch = window.fetch;
+        window.fetch = (url, options, ...rest) => {
+            if (typeof url === 'string' && url.startsWith('/')) {
+                return originalFetch(basePath + url, options, ...rest);
+            }
+            return originalFetch(url, options, ...rest);
+        };
+
         window.addEventListener('DOMContentLoaded', checkDatabaseStatus);
     </script>
 </body>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "AllGasNoBrakes/app.py", "use": "@vercel/python" },
+    { "src": "CampingCalendar/api/index.py", "use": "@vercel/python", "config": { "maxLambdaSize": "15mb" } },
+    { "src": "CampingCalendar/static/**", "use": "@vercel/static" },
+    { "src": "MovieRatings/api/index.py", "use": "@vercel/python", "config": { "maxLambdaSize": "15mb" } },
+    { "src": "MovieRatings/static/**", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "src": "/allgasnobrakes", "dest": "AllGasNoBrakes/app.py" },
+    { "src": "/allgasnobrakes/(.*)", "dest": "AllGasNoBrakes/app.py" },
+    { "src": "/camping/static/(.*)", "dest": "CampingCalendar/static/$1" },
+    { "src": "/camping", "dest": "CampingCalendar/api/index.py" },
+    { "src": "/camping/(.*)", "dest": "CampingCalendar/api/index.py" },
+    { "src": "/movieratings/static/(.*)", "dest": "MovieRatings/static/$1" },
+    { "src": "/movieratings", "dest": "MovieRatings/api/index.py" },
+    { "src": "/movieratings/(.*)", "dest": "MovieRatings/api/index.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add configurable `BASE_PATH` to each Flask app and expose it to templates
- Prefix static assets and internal links with the app base path
- Inject base path into client scripts and override `fetch` for relative API calls
- Add root `vercel.json` to route `/camping`, `/allgasnobrakes`, and `/movieratings`

## Testing
- `pytest` *(fails: fixture 'postgresql' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e725f4788325a627bbca4922a4ea