### PR TITLE
Overhaul trend chart, fix display bugs, restyle alarm panel

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -5,7 +5,18 @@ import time
 app = Flask(__name__, template_folder='../templates', static_folder='../static')
 
 TAILSCALE_BASE = 'https://thinkpad.tail824ac3.ts.net'
+# Module-level cache: best-effort on Vercel (resets on cold start, not shared
+# across instances). Key space is bounded by clamping query params below.
 _cache = {}
+
+
+def clamp_int(value, default, lo, hi):
+    """Coerce a query param to an int within [lo, hi], falling back to default."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
 
 
 def get_cached(key, ttl_seconds, fetch_fn):
@@ -32,7 +43,7 @@ def index():
 @app.route('/api/sensor')
 def proxy_sensor():
     device = request.args.get('device', 'office')
-    hours = request.args.get('hours', '24')
+    hours = clamp_int(request.args.get('hours'), 24, 1, 168)
     cache_key = f"sensor:{device}:{hours}"
 
     def fetch():
@@ -51,8 +62,8 @@ def proxy_sensor():
 @app.route('/api/sensor/log')
 def proxy_log():
     device = request.args.get('device', 'office')
-    hours = request.args.get('hours', '24')
-    limit = request.args.get('limit', '50')
+    hours = clamp_int(request.args.get('hours'), 24, 1, 168)
+    limit = clamp_int(request.args.get('limit'), 50, 1, 200)
     cache_key = f"log:{device}:{hours}:{limit}"
 
     def fetch():

--- a/api/index.py
+++ b/api/index.py
@@ -5,9 +5,17 @@ import time
 app = Flask(__name__, template_folder='../templates', static_folder='../static')
 
 TAILSCALE_BASE = 'https://thinkpad.tail824ac3.ts.net'
+# Supported devices. Whitelisting keeps the cache key space bounded and stops
+# arbitrary `device` values from being forwarded upstream on a public deploy.
+ALLOWED_DEVICES = {'office'}
 # Module-level cache: best-effort on Vercel (resets on cold start, not shared
-# across instances). Key space is bounded by clamping query params below.
+# across instances). Key space is bounded by the device whitelist + clamped params.
 _cache = {}
+
+
+def normalize_device(value):
+    """Return the device if it's a supported one, else None (callers reject)."""
+    return value if value in ALLOWED_DEVICES else None
 
 
 def clamp_int(value, default, lo, hi):
@@ -42,7 +50,9 @@ def index():
 
 @app.route('/api/sensor')
 def proxy_sensor():
-    device = request.args.get('device', 'office')
+    device = normalize_device(request.args.get('device', 'office'))
+    if device is None:
+        return jsonify({"error": "unknown device"}), 400
     hours = clamp_int(request.args.get('hours'), 24, 1, 168)
     cache_key = f"sensor:{device}:{hours}"
 
@@ -61,7 +71,9 @@ def proxy_sensor():
 
 @app.route('/api/sensor/log')
 def proxy_log():
-    device = request.args.get('device', 'office')
+    device = normalize_device(request.args.get('device', 'office'))
+    if device is None:
+        return jsonify({"error": "unknown device"}), 400
     hours = clamp_int(request.args.get('hours'), 24, 1, 168)
     limit = clamp_int(request.args.get('limit'), 50, 1, 200)
     cache_key = f"log:{device}:{hours}:{limit}"
@@ -81,7 +93,9 @@ def proxy_log():
 
 @app.route('/api/sensor/calibration')
 def proxy_calibration():
-    device = request.args.get('device', 'office')
+    device = normalize_device(request.args.get('device', 'office'))
+    if device is None:
+        return jsonify({"error": "unknown device"}), 400
     cache_key = f"calibration:{device}"
 
     def fetch():

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -197,15 +197,72 @@ body {
 }
 
 /* Alarm Panel */
+.alarm-panel { align-self: start; }
+
 .alarm-list {
+  flex: 0 1 auto;
   min-height: 150px;
-  flex: 1;
-  overflow-y: hidden;
+  max-height: 360px;
+  overflow-y: auto;
   border: 1px solid;
   border-color: #808080 #ffffff #ffffff #808080;
   background: var(--panel);
   font-family: "Courier New", monospace;
   font-size: 10px;
+  /* Firefox: native scrollbar, themed to the panel chrome */
+  scrollbar-width: auto;
+  scrollbar-color: var(--btn-face) #d4d0c8;
+}
+
+/* Win95-style scrollbar (WebKit/Blink) to match the beveled SCADA chrome */
+.alarm-list::-webkit-scrollbar {
+  width: 16px;
+}
+
+/* Dithered checkerboard track, like classic Windows */
+.alarm-list::-webkit-scrollbar-track {
+  background: repeating-conic-gradient(#c0c0c0 0% 25%, #efefef 0% 50%) 0 0 / 2px 2px;
+  border-left: 1px solid #808080;
+}
+
+/* Raised, beveled thumb (button face) */
+.alarm-list::-webkit-scrollbar-thumb {
+  background: var(--btn-face);
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  min-height: 24px;
+}
+
+.alarm-list::-webkit-scrollbar-thumb:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+/* Beveled arrow buttons at each end */
+.alarm-list::-webkit-scrollbar-button:single-button {
+  width: 16px;
+  height: 16px;
+  background-color: var(--btn-face);
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 8px 8px;
+}
+
+.alarm-list::-webkit-scrollbar-button:single-button:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.alarm-list::-webkit-scrollbar-button:single-button:vertical:decrement {
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8'><path d='M4 1 L7 6 L1 6 Z' fill='black'/></svg>");
+}
+
+.alarm-list::-webkit-scrollbar-button:single-button:vertical:increment {
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8'><path d='M1 2 L7 2 L4 7 Z' fill='black'/></svg>");
+}
+
+.alarm-list::-webkit-scrollbar-corner {
+  background: var(--btn-face);
 }
 
 .alarm-row {
@@ -349,16 +406,7 @@ body {
   overflow: hidden;
 }
 
-.trend-grid {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  background-image: 
-    repeating-linear-gradient(0deg, #003300 0, #003300 1px, transparent 1px, transparent 20px),
-    repeating-linear-gradient(90deg, #003300 0, #003300 1px, transparent 1px, transparent 20px);
-}
-
-/* Ensure the canvas overlays the grid and scales with the container */
+/* Canvas fills the chart container; gridlines are drawn on the canvas itself */
 #trend-canvas {
   position: absolute;
   inset: 0;
@@ -366,6 +414,8 @@ body {
   height: 100%;
   display: block;
   z-index: 1;
+  touch-action: none;   /* allow touch-drag to inspect without scrolling */
+  cursor: crosshair;
 }
 
 .wide { grid-column: span 2; }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -7,28 +7,43 @@
   const EVENT_POLL_INTERVAL = 60000; // refresh events every 1 minute
   const EVENT_HOURS = 72;
   const EVENT_LIMIT = 50;
-  const EVENT_DISPLAY_LIMIT = 16;
   const DAY_MS = 24 * 60 * 60 * 1000;
   const CALIBRATION_WARNING_DAYS = 7;
   const CALIBRATION_DUE_DAYS = 30;
 
+  // Trend chart
+  const TREND_WINDOW_MS = 24 * 60 * 60 * 1000;
+  // Alarm thresholds (shared by the live readout and the trend reference lines)
+  const CO2_WARN = 700;
+  const CO2_CRIT = 1200;
+  const TEMP_WARN_C = 23.3;
+  const TEMP_CRIT_C = 24.4;
+  // Fixed-scale bounds (CO2 ppm, temp °C) used when Trend Scale = Fixed
+  const TREND_FIXED_CO2 = [400, 1600];
+  const TREND_FIXED_TEMP_C = [18, 28];
+
   let sensorData = [];
   let eventData = [];
   let lastCalibrationEvent = null;
+  let trendGeom = null;   // cached chart geometry for crosshair hit-testing
+  let hover = null;       // { ts } currently hovered sample, or null
 
   // Unit preference settings
-  const DEFAULT_SETTINGS = { tempUnit: 'C', humidityUnit: 'RH' };
+  const DEFAULT_SETTINGS = { tempUnit: 'C', humidityUnit: 'RH', trendScale: 'auto' };
   // humidityUnit: 'RH' = %RH, 'AH_METRIC' = g/m³, 'AH_IMPERIAL' = gr/lb
+  // trendScale: 'auto' = autoscale to data, 'fixed' = fixed bounds
   let settings = { ...DEFAULT_SETTINGS };
 
   function loadSettings() {
     settings.tempUnit = localStorage.getItem('scada_tempUnit') || DEFAULT_SETTINGS.tempUnit;
     settings.humidityUnit = localStorage.getItem('scada_humidityUnit') || DEFAULT_SETTINGS.humidityUnit;
+    settings.trendScale = localStorage.getItem('scada_trendScale') || DEFAULT_SETTINGS.trendScale;
   }
 
   function saveSettings() {
     localStorage.setItem('scada_tempUnit', settings.tempUnit);
     localStorage.setItem('scada_humidityUnit', settings.humidityUnit);
+    localStorage.setItem('scada_trendScale', settings.trendScale);
   }
 
   // Temperature conversions
@@ -37,19 +52,29 @@
   function getTempUnit() { return settings.tempUnit === 'F' ? '°F' : '°C'; }
 
   // Humidity conversions
-  // Magnus formula: AH (g/m³) = (6.112 × e^((17.67×T)/(T+243.5)) × RH × 2.1674) / (273.15 + T)
-  function relativeToAbsoluteHumidity(rhPercent, tempC) {
-    const saturationPressure = 6.112 * Math.exp((17.67 * tempC) / (tempC + 243.5));
-    return (saturationPressure * rhPercent * 2.1674) / (273.15 + tempC);
+  // Magnus saturation vapor pressure (hPa)
+  function saturationPressureHpa(tempC) {
+    return 6.112 * Math.exp((17.67 * tempC) / (tempC + 243.5));
   }
 
-  // Convert g/m³ to grains/lb (1 g/m³ ≈ 7 gr/lb at standard conditions)
-  function gramsToGrains(gPerM3) { return gPerM3 * 7; }
+  // AH (g/m³) = (Psat × RH × 2.1674) / (273.15 + T)
+  function relativeToAbsoluteHumidity(rhPercent, tempC) {
+    return (saturationPressureHpa(tempC) * rhPercent * 2.1674) / (273.15 + tempC);
+  }
+
+  // Grains of moisture per pound of dry air = humidity ratio × 7000, at standard
+  // sea-level pressure. W = 0.62198 × Pw / (P − Pw), with Pw = Psat × RH/100.
+  function relativeToGrainsPerPound(rhPercent, tempC) {
+    const ATM_PRESSURE_HPA = 1013.25;
+    const vaporPressure = saturationPressureHpa(tempC) * (rhPercent / 100);
+    const humidityRatio = (0.62198 * vaporPressure) / (ATM_PRESSURE_HPA - vaporPressure);
+    return humidityRatio * 7000;
+  }
 
   function convertHumidity(rhPercent, tempC) {
     if (settings.humidityUnit === 'RH') return rhPercent;
-    const ahMetric = relativeToAbsoluteHumidity(rhPercent, tempC);
-    return settings.humidityUnit === 'AH_IMPERIAL' ? gramsToGrains(ahMetric) : ahMetric;
+    if (settings.humidityUnit === 'AH_IMPERIAL') return relativeToGrainsPerPound(rhPercent, tempC);
+    return relativeToAbsoluteHumidity(rhPercent, tempC);
   }
 
   function getHumidityUnit() {
@@ -76,10 +101,24 @@
     el.textContent = `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}`;
   }
 
+  // America/Chicago formatters (avoid the localized-string round-trip hack)
+  const TIME_24H_FMT = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'America/Chicago', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+  });
+  const TIME_HHMM_FMT = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'America/Chicago', hour: '2-digit', minute: '2-digit', hour12: false
+  });
+  const TIME_12H_FMT = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Chicago', hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: true
+  });
+  const CAL_DATE_FMT = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago', year: 'numeric', month: '2-digit', day: '2-digit'
+  });
+
   function formatTimestamp(isoString) {
     const d = new Date(isoString);
-    const central = new Date(d.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-    return `${pad2(central.getHours())}:${pad2(central.getMinutes())}:${pad2(central.getSeconds())}`;
+    if (Number.isNaN(d.getTime())) return '--:--:--';
+    return TIME_24H_FMT.format(d);
   }
 
   async function fetchSensorData() {
@@ -171,11 +210,9 @@
     // Get the last reset timestamp to mark acknowledged events
     const lastReset = getLastResetTimestamp(eventData);
 
-    // eventData is already sorted DESC by the API. Show the most recent rows
-    // without making the alarm panel drive the surrounding grid height.
-    const displayEvents = eventData.slice(0, EVENT_DISPLAY_LIMIT);
-
-    displayEvents.forEach(event => {
+    // eventData is already sorted DESC by the API. Render all fetched rows;
+    // the alarm list is content-sized and scrolls past its CSS max-height.
+    eventData.forEach(event => {
       const row = document.createElement('div');
       const eventTime = new Date(event.ts);
       const isAcknowledged = lastReset && eventTime < lastReset && event.event_type !== 'info';
@@ -225,10 +262,16 @@
   }
 
   function getLastResetTimestamp(events) {
-    // Find the most recent info event - this marks when alarms were "reset"
-    const infoEvent = events.find(e => e.event_type === 'info');
-    if (!infoEvent) return null;
-    return new Date(infoEvent.ts);
+    // Alarms are cleared on device reboot. The firmware emits no dedicated reset
+    // event, so anchor on the boot event ("Sensor started, serial: ...") rather
+    // than any info event (routine "Health:" heartbeats are also info).
+    const bootEvent = events.find(e =>
+      e.event_type === 'info' &&
+      e.message &&
+      e.message.includes('Sensor started')
+    );
+    if (!bootEvent) return null;
+    return new Date(bootEvent.ts);
   }
 
   function updateEventLed() {
@@ -268,35 +311,53 @@
     const lastCalSpan = document.getElementById('last-cal');
     if (!lastCalSpan) return;
 
-    if (lastCalibrationEvent && lastCalibrationEvent.ts) {
-      const calDate = new Date(lastCalibrationEvent.ts);
-      if (Number.isNaN(calDate.getTime())) {
-        lastCalSpan.textContent = 'ERR';
-        lastCalSpan.style.color = '#ff0000';
-        lastCalSpan.title = 'Calibration date unavailable';
-        return;
-      }
-
-      const yyyy = calDate.getFullYear();
-      const mm = String(calDate.getMonth() + 1).padStart(2, '0');
-      const dd = String(calDate.getDate()).padStart(2, '0');
-      const ageDays = Math.max(0, Math.floor((Date.now() - calDate.getTime()) / DAY_MS));
-
-      lastCalSpan.textContent = `${yyyy}-${mm}-${dd}`;
-      if (ageDays > CALIBRATION_DUE_DAYS) {
-        lastCalSpan.style.color = '#ff0000';
-        lastCalSpan.title = 'Calibration older than 30 days - calibration needed';
-      } else if (ageDays > CALIBRATION_WARNING_DAYS) {
-        lastCalSpan.style.color = '#ffff00';
-        lastCalSpan.title = 'Calibration older than 7 days';
-      } else {
-        lastCalSpan.style.color = '';
-        lastCalSpan.title = 'Calibration current';
-      }
-    } else {
+    const setErr = () => {
       lastCalSpan.textContent = 'ERR';
       lastCalSpan.style.color = '#ff0000';
       lastCalSpan.title = 'Calibration date unavailable';
+    };
+
+    if (!lastCalibrationEvent || !lastCalibrationEvent.ts) {
+      setErr();
+      return;
+    }
+
+    const raw = String(lastCalibrationEvent.ts);
+    let display;
+    let calMs;
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+      // Date-only string is already the calendar date. Parse as local midnight
+      // (not UTC) so the age calc doesn't shift the day west of UTC.
+      display = raw;
+      calMs = new Date(`${raw}T00:00:00`).getTime();
+    } else {
+      // Full ISO timestamp: show the America/Chicago calendar date.
+      const d = new Date(raw);
+      if (Number.isNaN(d.getTime())) {
+        setErr();
+        return;
+      }
+      display = CAL_DATE_FMT.format(d); // en-CA => YYYY-MM-DD
+      calMs = d.getTime();
+    }
+
+    if (Number.isNaN(calMs)) {
+      setErr();
+      return;
+    }
+
+    const ageDays = Math.max(0, Math.floor((Date.now() - calMs) / DAY_MS));
+    lastCalSpan.textContent = display;
+    if (ageDays > CALIBRATION_DUE_DAYS) {
+      lastCalSpan.style.color = '#ff0000';
+      lastCalSpan.title = 'Calibration older than 30 days - calibration needed';
+    } else if (ageDays > CALIBRATION_WARNING_DAYS) {
+      lastCalSpan.style.color = '#ffff00';
+      lastCalSpan.title = 'Calibration older than 7 days';
+    } else {
+      lastCalSpan.style.color = '';
+      lastCalSpan.title = 'Calibration current';
     }
   }
 
@@ -312,18 +373,18 @@
     
     if (co2El && latest.co2 != null) {
       co2El.textContent = String(latest.co2).padStart(4, '0');
-      // CO2: yellow > 700, red > 1200
+      // CO2: yellow > CO2_WARN, red > CO2_CRIT
       co2El.parentElement.classList.remove('warning', 'critical');
-      if (latest.co2 > 1200) co2El.parentElement.classList.add('critical');
-      else if (latest.co2 > 700) co2El.parentElement.classList.add('warning');
+      if (latest.co2 > CO2_CRIT) co2El.parentElement.classList.add('critical');
+      else if (latest.co2 > CO2_WARN) co2El.parentElement.classList.add('warning');
     }
     if (tempEl && latest.temp != null) {
       const displayTemp = convertTemp(latest.temp);
       tempEl.textContent = displayTemp.toFixed(1);
-      // Temp thresholds in Celsius: yellow > 23.3°C, red > 24.4°C
+      // Temp thresholds in Celsius: yellow > TEMP_WARN_C, red > TEMP_CRIT_C
       tempEl.parentElement.classList.remove('warning', 'critical');
-      if (latest.temp > 24.4) tempEl.parentElement.classList.add('critical');
-      else if (latest.temp > 23.3) tempEl.parentElement.classList.add('warning');
+      if (latest.temp > TEMP_CRIT_C) tempEl.parentElement.classList.add('critical');
+      else if (latest.temp > TEMP_WARN_C) tempEl.parentElement.classList.add('warning');
     }
     if (humidityEl && latest.humidity != null) {
       const displayHumidity = convertHumidity(latest.humidity, latest.temp);
@@ -339,23 +400,18 @@
     const lastUpdateEl = document.getElementById('last-update');
     if (lastUpdateEl && latest.ts) {
       const d = new Date(latest.ts);
-      const central = new Date(d.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-      const month = pad2(central.getMonth() + 1);
-      const day = pad2(central.getDate());
-      const year = String(central.getFullYear()).slice(-2);
-      let hour = central.getHours();
-      const ampm = hour >= 12 ? 'pm' : 'am';
-      hour = hour % 12 || 12;
-      const minute = pad2(central.getMinutes());
-      const second = pad2(central.getSeconds());
-      lastUpdateEl.textContent = `${hour}:${minute}.${second} ${ampm}`;
+      if (!Number.isNaN(d.getTime())) {
+        const parts = {};
+        for (const p of TIME_12H_FMT.formatToParts(d)) parts[p.type] = p.value;
+        const ampm = (parts.dayPeriod || '').toLowerCase();
+        lastUpdateEl.textContent = `${parts.hour}:${parts.minute}.${parts.second} ${ampm}`;
 
-      // Last Update: yellow > 15 min, red > 25 min stale (adjusted for 10-min batching)
-      const ageMs = Date.now() - d.getTime();
-      const ageMin = ageMs / 60000;
-      lastUpdateEl.parentElement.classList.remove('warning', 'critical');
-      if (ageMin > 25) lastUpdateEl.parentElement.classList.add('critical');
-      else if (ageMin > 15) lastUpdateEl.parentElement.classList.add('warning');
+        // Last Update: yellow > 15 min, red > 25 min stale (adjusted for 10-min batching)
+        const ageMin = (Date.now() - d.getTime()) / 60000;
+        lastUpdateEl.parentElement.classList.remove('warning', 'critical');
+        if (ageMin > 25) lastUpdateEl.parentElement.classList.add('critical');
+        else if (ageMin > 15) lastUpdateEl.parentElement.classList.add('warning');
+      }
     }
   }
 
@@ -368,15 +424,248 @@
     }
   }
 
+  // ---- Trend chart ----------------------------------------------------------
+
+  function median(nums) {
+    if (nums.length === 0) return 0;
+    const s = [...nums].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  }
+
+  // Parse sensorData into {ts, co2, temp} sorted ascending by time.
+  function getTrendPoints() {
+    return sensorData
+      .map(d => ({ ts: new Date(d.ts).getTime(), co2: d.co2, temp: d.temp }))
+      .filter(p => !Number.isNaN(p.ts))
+      .sort((a, b) => a.ts - b.ts);
+  }
+
+  // Range for one series; null when no data. Fixed mode ignores the data.
+  function seriesRange(points, key, padAmt, fixed) {
+    if (settings.trendScale === 'fixed') return { min: fixed[0], max: fixed[1] };
+    const vals = points.map(p => p[key]).filter(v => v != null);
+    if (vals.length === 0) return null;
+    return { min: Math.min(...vals) - padAmt, max: Math.max(...vals) + padAmt };
+  }
+
+  // ms to add to a UTC instant to get wall-clock time in tz (handles DST).
+  function tzOffsetMs(date, tz) {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit'
+    });
+    const p = {};
+    for (const x of dtf.formatToParts(date)) p[x.type] = x.value;
+    const hour = p.hour === '24' ? 0 : Number(p.hour);
+    const asUTC = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day),
+      hour, Number(p.minute), Number(p.second));
+    return asUTC - date.getTime();
+  }
+
+  // 6h ticks aligned to round Chicago clock hours (00/06/12/18).
+  function sixHourTicks(g) {
+    const SIX_H = 6 * 60 * 60 * 1000;
+    const off = tzOffsetMs(new Date(g.tEnd), 'America/Chicago');
+    const ticks = [];
+    let t = Math.ceil((g.tStart + off) / SIX_H) * SIX_H - off;
+    for (; t <= g.tEnd; t += SIX_H) ticks.push(t);
+    return ticks;
+  }
+
+  // Gap larger than this breaks the line (downtime). >= 20 min.
+  function trendGapMs(points) {
+    const deltas = [];
+    let prev = null;
+    for (const p of points) {
+      if (prev != null) deltas.push(p.ts - prev);
+      prev = p.ts;
+    }
+    return Math.max(2 * median(deltas), 20 * 60 * 1000);
+  }
+
+  function computeTrendGeom(canvas) {
+    const parent = canvas.parentElement;
+    const widthCSS = parent.clientWidth || 300;
+    const heightCSS = parent.clientHeight || 200;
+    const padding = { top: 24, right: 60, bottom: 30, left: 50 };
+    const points = getTrendPoints();
+    const tEnd = Date.now();
+    return {
+      widthCSS, heightCSS, padding,
+      chartWidth: widthCSS - padding.left - padding.right,
+      chartHeight: heightCSS - padding.top - padding.bottom,
+      tStart: tEnd - TREND_WINDOW_MS,
+      tEnd,
+      points,
+      co2: seriesRange(points, 'co2', 50, TREND_FIXED_CO2),
+      temp: seriesRange(points, 'temp', 2, TREND_FIXED_TEMP_C),
+    };
+  }
+
+  function xAt(g, ts) {
+    return g.padding.left + g.chartWidth * (ts - g.tStart) / (g.tEnd - g.tStart);
+  }
+  function yAt(g, range, value) {
+    return g.heightCSS - g.padding.bottom -
+      ((value - range.min) / (range.max - range.min)) * g.chartHeight;
+  }
+  function crisp(v) { return Math.round(v) + 0.5; }
+
+  // Draw one series with gap breaks. Returns the most recent drawn point.
+  function drawSeries(ctx, g, range, key, color, gapMs) {
+    if (!range) return null;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    let prevTs = null, started = false, last = null;
+    for (const p of g.points) {
+      if (p[key] == null) { prevTs = null; started = false; continue; }
+      if (p.ts < g.tStart) { prevTs = p.ts; continue; }
+      const x = xAt(g, p.ts), y = yAt(g, range, p[key]);
+      if (!started || (prevTs != null && p.ts - prevTs > gapMs)) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+      started = true;
+      prevTs = p.ts;
+      last = { x, y, value: p[key] };
+    }
+    ctx.stroke();
+    return last;
+  }
+
+  function drawThreshold(ctx, g, range, value, color, label, side) {
+    if (!range || value < range.min || value > range.max) return;
+    const y = yAt(g, range, value);
+    const right = g.widthCSS - g.padding.right;
+    ctx.save();
+    ctx.strokeStyle = color;
+    ctx.globalAlpha = 0.65;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath();
+    ctx.moveTo(g.padding.left, crisp(y));
+    ctx.lineTo(right, crisp(y));
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 0.9;
+    ctx.fillStyle = color;
+    ctx.font = '8px "Courier New", monospace';
+    ctx.textAlign = side === 'left' ? 'left' : 'right';
+    ctx.fillText(label, side === 'left' ? g.padding.left + 3 : right - 3, y - 2);
+    ctx.restore();
+  }
+
+  function drawMarker(ctx, g, pt, color, label) {
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(pt.x, pt.y, 2.5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.font = '9px "Courier New", monospace';
+    ctx.textAlign = 'right';
+    ctx.fillText(label, Math.min(pt.x - 4, g.widthCSS - g.padding.right - 2), pt.y - 4);
+  }
+
+  function drawLegend(ctx, g) {
+    ctx.font = '10px "Courier New", monospace';
+    ctx.textAlign = 'left';
+    const sw = 8, sy = 4;
+    ctx.fillStyle = '#00ff00';
+    ctx.fillRect(g.padding.left, sy, sw, sw);
+    ctx.fillText('CO2 (ppm)', g.padding.left + sw + 4, 12);
+    const x2 = g.padding.left + 95;
+    ctx.fillStyle = '#ff6600';
+    ctx.fillRect(x2, sy, sw, sw);
+    ctx.fillText('Temp (' + getTempUnit() + ')', x2 + sw + 4, 12);
+  }
+
+  function drawStats(ctx, g) {
+    ctx.font = '8px "Courier New", monospace';
+    ctx.textAlign = 'right';
+    const rx = g.widthCSS - g.padding.right;
+    const co2 = g.points.map(p => p.co2).filter(v => v != null);
+    if (co2.length) {
+      const avg = co2.reduce((a, b) => a + b, 0) / co2.length;
+      ctx.fillStyle = '#00ff00';
+      ctx.fillText(`CO2 ${Math.round(Math.min(...co2))}/${Math.round(avg)}/${Math.round(Math.max(...co2))}`, rx, 9);
+    }
+    const temp = g.points.map(p => p.temp).filter(v => v != null);
+    if (temp.length) {
+      const avg = temp.reduce((a, b) => a + b, 0) / temp.length;
+      ctx.fillStyle = '#ff6600';
+      ctx.fillText(`T ${convertTemp(Math.min(...temp)).toFixed(1)}/${convertTemp(avg).toFixed(1)}/${convertTemp(Math.max(...temp)).toFixed(1)}`, rx, 18);
+    }
+  }
+
+  function nearestSample(points, ts) {
+    if (points.length === 0) return null;
+    let lo = 0, hi = points.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (points[mid].ts < ts) lo = mid + 1; else hi = mid;
+    }
+    const cand = lo > 0 ? [points[lo], points[lo - 1]] : [points[lo]];
+    return cand.reduce((best, p) => Math.abs(p.ts - ts) < Math.abs(best.ts - ts) ? p : best);
+  }
+
+  function drawCrosshair(ctx, g) {
+    const sample = nearestSample(g.points, hover.ts);
+    if (!sample) return;
+    const x = xAt(g, sample.ts);
+    const left = g.padding.left, right = g.widthCSS - g.padding.right;
+    if (x < left || x > right) return;
+    const top = g.padding.top, bottom = g.heightCSS - g.padding.bottom;
+
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([2, 2]);
+    ctx.beginPath();
+    ctx.moveTo(crisp(x), top);
+    ctx.lineTo(crisp(x), bottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    const rows = [{ c: '#ffffff', t: TIME_HHMM_FMT.format(new Date(sample.ts)) }];
+    if (g.co2 && sample.co2 != null) {
+      const y = yAt(g, g.co2, sample.co2);
+      ctx.fillStyle = '#00ff00';
+      ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
+      rows.push({ c: '#00ff00', t: `CO2 ${Math.round(sample.co2)} ppm` });
+    }
+    if (g.temp && sample.temp != null) {
+      const y = yAt(g, g.temp, sample.temp);
+      ctx.fillStyle = '#ff6600';
+      ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
+      rows.push({ c: '#ff6600', t: `T ${convertTemp(sample.temp).toFixed(1)}${getTempUnit()}` });
+    }
+
+    ctx.font = '9px "Courier New", monospace';
+    const tw = Math.max(...rows.map(r => ctx.measureText(r.t).width)) + 12;
+    const th = rows.length * 12 + 6;
+    let bx = x + 8;
+    if (bx + tw > right) bx = x - 8 - tw;
+    const by = top + 4;
+    ctx.fillStyle = 'rgba(0,0,0,0.8)';
+    ctx.fillRect(bx, by, tw, th);
+    ctx.strokeStyle = '#5f9f5f';
+    ctx.strokeRect(crisp(bx), crisp(by), tw, th);
+    ctx.textAlign = 'left';
+    rows.forEach((r, i) => {
+      ctx.fillStyle = r.c;
+      ctx.fillText(r.t, bx + 6, by + 12 + i * 12);
+    });
+    ctx.restore();
+  }
+
   function drawTrend() {
     const canvas = document.getElementById('trend-canvas');
     if (!canvas) return;
 
-    const parent = canvas.parentElement;
     const dpr = window.devicePixelRatio || 1;
+    const parent = canvas.parentElement;
     const widthCSS = parent.clientWidth || 300;
     const heightCSS = parent.clientHeight || 200;
-
     canvas.width = Math.max(1, Math.floor(widthCSS * dpr));
     canvas.height = Math.max(1, Math.floor(heightCSS * dpr));
     canvas.style.width = widthCSS + 'px';
@@ -384,107 +673,129 @@
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.scale(dpr, dpr);
     ctx.clearRect(0, 0, widthCSS, heightCSS);
 
-    if (sensorData.length < 2) {
-      // No data yet - show placeholder text
+    const g = computeTrendGeom(canvas);
+    trendGeom = g;
+
+    if (g.points.length < 2 || (!g.co2 && !g.temp)) {
       ctx.fillStyle = '#00ff00';
       ctx.font = '12px "Courier New", monospace';
       ctx.fillText('Waiting for sensor data...', 10, heightCSS / 2);
       return;
     }
 
-    const padding = { top: 20, right: 60, bottom: 30, left: 50 };
-    const chartWidth = widthCSS - padding.left - padding.right;
-    const chartHeight = heightCSS - padding.top - padding.bottom;
+    const { padding, chartWidth, chartHeight } = g;
+    const left = padding.left, right = widthCSS - padding.right;
+    const top = padding.top, bottom = heightCSS - padding.bottom;
+    const ticks = sixHourTicks(g);
 
-    // Extract CO2 values and find range
-    const co2Values = sensorData.map(d => d.co2).filter(v => v != null);
-    const tempValues = sensorData.map(d => d.temp).filter(v => v != null);
-    
-    const co2Min = Math.min(...co2Values) - 50;
-    const co2Max = Math.max(...co2Values) + 50;
-    const tempMin = Math.min(...tempValues) - 2;
-    const tempMax = Math.max(...tempValues) + 2;
+    // Gridlines
+    ctx.strokeStyle = '#0a2a0a';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let i = 0; i <= 4; i++) {
+      const y = crisp(bottom - chartHeight * i / 4);
+      ctx.moveTo(left, y); ctx.lineTo(right, y);
+    }
+    for (const t of ticks) {
+      const x = crisp(xAt(g, t));
+      ctx.moveTo(x, top); ctx.lineTo(x, bottom);
+    }
+    ctx.stroke();
 
-    // Draw axes
+    // Threshold reference lines (in-range only)
+    drawThreshold(ctx, g, g.co2, CO2_WARN, '#00aa00', String(CO2_WARN), 'left');
+    drawThreshold(ctx, g, g.co2, CO2_CRIT, '#00aa00', String(CO2_CRIT), 'left');
+    drawThreshold(ctx, g, g.temp, TEMP_WARN_C, '#cc6600', convertTemp(TEMP_WARN_C).toFixed(1) + '°', 'right');
+    drawThreshold(ctx, g, g.temp, TEMP_CRIT_C, '#cc6600', convertTemp(TEMP_CRIT_C).toFixed(1) + '°', 'right');
+
+    // Axes (L-shape)
     ctx.strokeStyle = '#004400';
     ctx.lineWidth = 1;
     ctx.beginPath();
-    ctx.moveTo(padding.left, padding.top);
-    ctx.lineTo(padding.left, heightCSS - padding.bottom);
-    ctx.lineTo(widthCSS - padding.right, heightCSS - padding.bottom);
+    ctx.moveTo(crisp(left), top);
+    ctx.lineTo(crisp(left), crisp(bottom));
+    ctx.lineTo(right, crisp(bottom));
     ctx.stroke();
 
-    // Y-axis labels (CO2 - left side)
-    ctx.fillStyle = '#00ff00';
+    // Y-axis labels
     ctx.font = '9px "Courier New", monospace';
-    ctx.textAlign = 'right';
-    for (let i = 0; i <= 4; i++) {
-      const val = co2Min + (co2Max - co2Min) * (i / 4);
-      const y = heightCSS - padding.bottom - (chartHeight * i / 4);
-      ctx.fillText(Math.round(val) + '', padding.left - 5, y + 3);
+    if (g.co2) {
+      ctx.fillStyle = '#00ff00';
+      ctx.textAlign = 'right';
+      for (let i = 0; i <= 4; i++) {
+        const val = g.co2.min + (g.co2.max - g.co2.min) * (i / 4);
+        ctx.fillText(Math.round(val) + '', left - 5, bottom - chartHeight * i / 4 + 3);
+      }
     }
-
-    // Y-axis labels (Temp - right side)
-    ctx.fillStyle = '#ff6600';
-    ctx.textAlign = 'left';
-    for (let i = 0; i <= 4; i++) {
-      const valCelsius = tempMin + (tempMax - tempMin) * (i / 4);
-      const displayVal = convertTemp(valCelsius);
-      const y = heightCSS - padding.bottom - (chartHeight * i / 4);
-      ctx.fillText(displayVal.toFixed(1) + '°', widthCSS - padding.right + 5, y + 3);
+    if (g.temp) {
+      ctx.fillStyle = '#ff6600';
+      ctx.textAlign = 'left';
+      for (let i = 0; i <= 4; i++) {
+        const valC = g.temp.min + (g.temp.max - g.temp.min) * (i / 4);
+        ctx.fillText(convertTemp(valC).toFixed(1) + '°', right + 5, bottom - chartHeight * i / 4 + 3);
+      }
     }
 
     // X-axis time labels
     ctx.fillStyle = '#008800';
     ctx.textAlign = 'center';
-    const timePoints = [0, Math.floor(sensorData.length / 2), sensorData.length - 1];
-    timePoints.forEach(idx => {
-      if (idx >= sensorData.length) return;
-      const d = new Date(sensorData[idx].ts);
-      const label = `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
-      const x = padding.left + (chartWidth * idx / (sensorData.length - 1));
-      ctx.fillText(label, x, heightCSS - padding.bottom + 15);
-    });
+    for (const t of ticks) {
+      ctx.fillText(TIME_HHMM_FMT.format(new Date(t)), xAt(g, t), bottom + 15);
+    }
 
-    // Draw CO2 line (green)
-    ctx.strokeStyle = '#00ff00';
-    ctx.lineWidth = 1.5;
+    // Series (clipped to the plot rect so fixed-scale overflow stays in-bounds)
+    const gapMs = trendGapMs(g.points);
+    ctx.save();
     ctx.beginPath();
-    sensorData.forEach((d, i) => {
-      if (d.co2 == null) return;
-      const x = padding.left + (chartWidth * i / (sensorData.length - 1));
-      const y = heightCSS - padding.bottom - ((d.co2 - co2Min) / (co2Max - co2Min)) * chartHeight;
-      if (i === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
-    });
-    ctx.stroke();
+    ctx.rect(left, top, chartWidth, chartHeight);
+    ctx.clip();
+    const lastCo2 = drawSeries(ctx, g, g.co2, 'co2', '#00ff00', gapMs);
+    const lastTemp = drawSeries(ctx, g, g.temp, 'temp', '#ff6600', gapMs);
+    ctx.restore();
 
-    // Draw temperature line (orange)
-    ctx.strokeStyle = '#ff6600';
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    sensorData.forEach((d, i) => {
-      if (d.temp == null) return;
-      const x = padding.left + (chartWidth * i / (sensorData.length - 1));
-      const y = heightCSS - padding.bottom - ((d.temp - tempMin) / (tempMax - tempMin)) * chartHeight;
-      if (i === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
-    });
-    ctx.stroke();
+    // Most-recent value markers
+    if (lastCo2) drawMarker(ctx, g, lastCo2, '#00ff00', String(Math.round(lastCo2.value)));
+    if (lastTemp) drawMarker(ctx, g, lastTemp, '#ff6600', convertTemp(lastTemp.value).toFixed(1) + '°');
 
-    // Legend
-    ctx.font = '10px "Courier New", monospace';
-    ctx.fillStyle = '#00ff00';
-    ctx.textAlign = 'left';
-    ctx.fillText('■ CO2 (ppm)', padding.left, 12);
-    ctx.fillStyle = '#ff6600';
-    ctx.fillText('■ Temp (' + getTempUnit() + ')', padding.left + 80, 12);
+    drawLegend(ctx, g);
+    drawStats(ctx, g);
 
+    if (hover) drawCrosshair(ctx, g);
+  }
+
+  // Crosshair interactivity (mouse + touch via Pointer Events)
+  let trendRAF = 0;
+  function scheduleTrendRedraw() {
+    if (trendRAF) return;
+    trendRAF = requestAnimationFrame(() => { trendRAF = 0; drawTrend(); });
+  }
+  function trendPointerMove(e) {
+    const g = trendGeom;
+    if (!g) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    if (x < g.padding.left || x > g.widthCSS - g.padding.right) {
+      if (hover) { hover = null; scheduleTrendRedraw(); }
+      return;
+    }
+    hover = { ts: g.tStart + (x - g.padding.left) / g.chartWidth * (g.tEnd - g.tStart) };
+    scheduleTrendRedraw();
+  }
+  function trendPointerClear() {
+    if (hover) { hover = null; scheduleTrendRedraw(); }
+  }
+  function initTrendInteractivity() {
+    const canvas = document.getElementById('trend-canvas');
+    if (!canvas) return;
+    canvas.addEventListener('pointermove', trendPointerMove);
+    canvas.addEventListener('pointerdown', trendPointerMove);
+    canvas.addEventListener('pointerleave', trendPointerClear);
+    canvas.addEventListener('pointerup', trendPointerClear);
+    canvas.addEventListener('pointercancel', trendPointerClear);
   }
 
   function renderConfigPopup(container) {
@@ -519,6 +830,19 @@
           </label>
         </div>
       </div>
+      <div class="config-section">
+        <div class="config-label">Trend Scale</div>
+        <div class="config-options">
+          <label class="config-radio">
+            <input type="radio" name="trendScale" value="auto" ${settings.trendScale === 'auto' ? 'checked' : ''}>
+            Auto (fit to data)
+          </label>
+          <label class="config-radio">
+            <input type="radio" name="trendScale" value="fixed" ${settings.trendScale === 'fixed' ? 'checked' : ''}>
+            Fixed (${TREND_FIXED_CO2[0]}–${TREND_FIXED_CO2[1]} ppm)
+          </label>
+        </div>
+      </div>
     `;
 
     // Add event listeners for immediate apply
@@ -535,6 +859,14 @@
         settings.humidityUnit = e.target.value;
         saveSettings();
         applySettings();
+      });
+    });
+
+    container.querySelectorAll('input[name="trendScale"]').forEach(input => {
+      input.addEventListener('change', (e) => {
+        settings.trendScale = e.target.value;
+        saveSettings();
+        drawTrend();
       });
     });
   }
@@ -643,6 +975,9 @@
 
     // Toolbar popup buttons
     initToolbarButtons();
+
+    // Trend crosshair (mouse + touch)
+    initTrendInteractivity();
   }
 
   if (document.readyState === 'loading') {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -449,28 +449,55 @@
     return { min: Math.min(...vals) - padAmt, max: Math.max(...vals) + padAmt };
   }
 
-  // ms to add to a UTC instant to get wall-clock time in tz (handles DST).
-  function tzOffsetMs(date, tz) {
-    const dtf = new Intl.DateTimeFormat('en-US', {
-      timeZone: tz, hour12: false,
-      year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit', second: '2-digit'
-    });
+  const CHICAGO_PARTS_FMT = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Chicago', hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  });
+
+  // Chicago wall-clock components for an instant.
+  function chicagoParts(date) {
     const p = {};
-    for (const x of dtf.formatToParts(date)) p[x.type] = x.value;
-    const hour = p.hour === '24' ? 0 : Number(p.hour);
-    const asUTC = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day),
-      hour, Number(p.minute), Number(p.second));
-    return asUTC - date.getTime();
+    for (const x of CHICAGO_PARTS_FMT.formatToParts(date)) p[x.type] = x.value;
+    return {
+      y: Number(p.year), mo: Number(p.month), d: Number(p.day),
+      h: p.hour === '24' ? 0 : Number(p.hour),
+      mi: Number(p.minute), s: Number(p.second)
+    };
   }
 
-  // 6h ticks aligned to round Chicago clock hours (00/06/12/18).
+  // Chicago UTC offset (ms to add to a UTC instant to get wall-clock) at `date`.
+  function chicagoOffsetMs(date) {
+    const p = chicagoParts(date);
+    return Date.UTC(p.y, p.mo - 1, p.d, p.h, p.mi, p.s) - date.getTime();
+  }
+
+  // Epoch ms for a given Chicago wall-clock time. Refines once so the offset is
+  // taken at the resulting instant, not the guess (correct across DST edges).
+  function chicagoWallToEpoch(y, mo, d, h) {
+    const utc = Date.UTC(y, mo - 1, d, h, 0, 0);
+    let e = utc - chicagoOffsetMs(new Date(utc));
+    e = utc - chicagoOffsetMs(new Date(e));
+    return e;
+  }
+
+  // 6h ticks aligned to round Chicago clock hours (00/06/12/18), DST-correct:
+  // each tick's offset is computed independently rather than reused across the
+  // window, so ticks before/after a transition stay on round hours.
   function sixHourTicks(g) {
     const SIX_H = 6 * 60 * 60 * 1000;
-    const off = tzOffsetMs(new Date(g.tEnd), 'America/Chicago');
+    const start = chicagoParts(new Date(g.tStart));
+    // UTC counter used purely to step Chicago wall-clock by 6h (00→06→12→18→…).
+    let wall = Date.UTC(start.y, start.mo - 1, start.d, 0, 0, 0);
     const ticks = [];
-    let t = Math.ceil((g.tStart + off) / SIX_H) * SIX_H - off;
-    for (; t <= g.tEnd; t += SIX_H) ticks.push(t);
+    for (let i = 0; i < 16; i++) {
+      const w = new Date(wall);
+      const epoch = chicagoWallToEpoch(w.getUTCFullYear(), w.getUTCMonth() + 1,
+        w.getUTCDate(), w.getUTCHours());
+      if (epoch > g.tEnd) break;
+      if (epoch >= g.tStart) ticks.push(epoch);
+      wall += SIX_H;
+    }
     return ticks;
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,6 @@
       <div class="panel-title">24-Hour Trend - CO2/Temperature</div>
       <div class="panel-body">
         <div class="trend-chart" role="img" aria-label="CO2/Temperature trend">
-          <div class="trend-grid" aria-hidden="true"></div>
           <canvas id="trend-canvas"></canvas>
         </div>
       </div>
@@ -44,7 +43,7 @@
     <div class="panel">
       <div class="panel-title">
         <span>Environmental Monitor - Office</span>
-        <span style="font-size: 9px;">LIVE | <a href="https://thinkpad.tail824ac3.ts.net/api/sensor?device=office&hours=24" style="color: inherit;">RAW</a></span>
+        <span style="font-size: 9px;">LIVE | <a href="/api/sensor?device=office&hours=24" style="color: inherit;">RAW</a></span>
       </div>
       <div class="panel-body">
         <div class="sensor-grid">
@@ -113,10 +112,10 @@
     </div>
 
     <!-- Alarm Summary - Now Dynamic -->
-    <div class="panel wide">
+    <div class="panel wide alarm-panel">
       <div class="panel-title">
         <span>Alarm Summary</span>
-        <span style="font-size: 9px;"><span id="alarm-count">0 ACTIVE</span> | CALIBRATED: <span id="last-cal">----</span> | <a href="https://thinkpad.tail824ac3.ts.net/api/sensor/log?device=office&hours=72" style="color: inherit;">RAW</a></span>
+        <span style="font-size: 9px;"><span id="alarm-count">0 ACTIVE</span> | CALIBRATED: <span id="last-cal">----</span> | <a href="/api/sensor/log?device=office&hours=72" style="color: inherit;">RAW</a></span>
       </div>
       <div class="panel-body">
         <div id="alarm-list" class="alarm-list" role="log" aria-live="polite">


### PR DESCRIPTION
Changes made this session, grouped by area.

## Alarm Summary panel
- **Size to content**: the alarm list now uses `align-self:start` + `max-height` with scroll, so it no longer stretches to fill the grid row and leaves a gray band (the original issue in `issue.png`).
- **Win95-style scrollbar**: dithered checkerboard track, beveled button-face thumb and arrow buttons that invert when pressed; Firefox falls back to themed `scrollbar-color`.

## Display / correctness fixes
- **Calibration date off-by-one**: handle date-only vs full-ISO sources and render in America/Chicago (no more day-early west of UTC).
- **Alarm reset anchor**: anchor on the device boot event (`Sensor started`) instead of any `info` event, so routine `Health:` heartbeats no longer auto-acknowledge real alarms.
- **Timestamp formatting**: replace the parse-localized-string hack with shared `Intl.DateTimeFormat` (Chicago) formatters; de-dupe across alarm rows, last-update, and trend labels.
- **Humidity gr/lb**: proper humidity-ratio formula (was a crude `g/m³ × 7` approximation; verified ~57.5 gr/lb @ 22 °C/50%RH).
- **RAW links**: routed through the Flask proxy — no internal tailnet host in page source.
- **API validation**: `clamp_int` for `hours` (1–168) and `limit` (1–200) in `api/index.py`, bounding the cache key space.

## 24-hour trend chart
- **Time-accurate**: plot by timestamp over a fixed 24h window (was index-based) and **break the line across data gaps**.
- **Readability**: aligned canvas gridlines, 6h ticks on round Chicago hours, in-range dashed threshold lines (CO2 700/1200, temp 23.3/24.4 — constants now shared with the live readout), last-value markers, min/avg/max stats, crisp axes, `fillRect` legend swatches.
- **Auto/Fixed scale toggle** in Config (persisted via `localStorage`).
- **Crosshair tooltip** with mouse + touch support.

## Verification
- `node --check` clean; Flask app boots, `/` returns 200, RAW links resolve to `/api/...` with no tailnet host in HTML.
- Pure-logic checks: Chicago 6h ticks align (DST-aware), nearest-sample + gap detection correct, `clamp_int` bounds, humidity math vs psychrometric reference.
- `issue.png` (debug screenshot) intentionally left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)